### PR TITLE
Colour coded InfoWindows

### DIFF
--- a/app/src/main/java/com/example/earth/fuelfriend/CustomInfoWindowAdapter.java
+++ b/app/src/main/java/com/example/earth/fuelfriend/CustomInfoWindowAdapter.java
@@ -1,15 +1,19 @@
 package com.example.earth.fuelfriend;
 
 import android.app.Activity;
+import android.graphics.PorterDuff;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.model.Marker;
 
 import static com.example.earth.fuelfriend.Constants.TRANSPORT_CAR;
-import static com.example.earth.fuelfriend.GeneralHelper.getTransportIcon;
+import static com.example.earth.fuelfriend.GeneralHelper.getTransportColor;
 
 /**
  * Created by EARTH on 6/08/2017.
@@ -34,6 +38,7 @@ public class CustomInfoWindowAdapter implements GoogleMap.InfoWindowAdapter{
 
         View view = context.getLayoutInflater().inflate(R.layout.custom_infowindow, null);
 
+        RelativeLayout rlBackground = (RelativeLayout) view.findViewById(R.id.rl_info_background);
         ImageView ivTransport = (ImageView) view.findViewById(R.id.iv_transport);
         TextView tvTitle = (TextView) view.findViewById(R.id.tv_title);
         TextView tvSubTitle = (TextView) view.findViewById(R.id.tv_subtitle);
@@ -42,11 +47,24 @@ public class CustomInfoWindowAdapter implements GoogleMap.InfoWindowAdapter{
         String transport = marker.getTitle();
         transport = transport.substring(transport.indexOf("|") + 1, transport.length()); // Anchoring the Transport method onto the marker title. Such a hack..
         String savingStatus = (transport.equals(TRANSPORT_CAR)) ? "Used" : "Saved";
-        
-        ivTransport.setImageResource(getTransportIcon(transport));
+
+        Drawable circle = view.getResources().getDrawable(R.drawable.circle);
+        circle.setColorFilter(view.getResources().getColor(R.color.colorBikeLine), PorterDuff.Mode.MULTIPLY);
+
+        GradientDrawable bgDrawable = (GradientDrawable) rlBackground.getBackground();
+        bgDrawable.setColor(getTransportColor(transport, context));
+
+        //ivTransport.setImageResource(getTransportIcon(transport));
         tvTitle.setText(marker.getTitle().substring(0, marker.getTitle().indexOf("|"))); // Removing the transport method before displaying title of marker
         tvSubTitle.setText(marker.getSnippet());
         tvSavingStatus.setText(savingStatus);
+        //Changes the colour
+        //tvSavingStatus.setTextColor(savingStatusColour(savingStatus, view));
         return view;
     }
+
+    private int savingStatusColour(String status, View view) {
+        return status.equals("Used") ? view.getResources().getColor(R.color.colorCarLine) : view.getResources().getColor(R.color.colorBikeLine);
+    }
+
 }

--- a/app/src/main/res/drawable/circle.xml
+++ b/app/src/main/res/drawable/circle.xml
@@ -11,12 +11,13 @@
   limitations under the License.
   -->
 <shape xmlns:android="http://schemas.android.com/apk/res/android"
-    android:shape="oval">
+    android:shape="oval"
+    android:id="@+id/circle_iw_bg">
     <size
-        android:width="100dp"
-        android:height="100dp" />
-    <stroke
-        android:width="3dp"
-        android:color="@color/colorInfoWindow" />
+        android:width="104dp"
+        android:height="104dp" />
+    <!--<stroke
+        android:width="1dp"
+        android:color="@color/colorInfoWindowFont" />-->
     <solid android:color="@color/colorInfoWindow" />
 </shape>

--- a/app/src/main/res/layout/custom_infowindow.xml
+++ b/app/src/main/res/layout/custom_infowindow.xml
@@ -5,6 +5,7 @@
     android:orientation="vertical">
 
     <RelativeLayout
+        android:id="@+id/rl_info_background"
         android:layout_width="150dp"
         android:layout_height="150dp"
         android:layout_centerInParent="true"
@@ -17,8 +18,9 @@
             android:layout_centerInParent="true"
             android:adjustViewBounds="false"
             android:gravity="center_vertical"
-            android:src="@drawable/ic_bike_24dp"
             android:tint="@color/colorInfoWindowDark" />
+        <!-- android:src="@drawable/ic_bike_24dp"-->
+
 
         <LinearLayout
             android:layout_width="wrap_content"


### PR DESCRIPTION
As title states, and also took away background Transport icon as the colours now represent the corresponding transport mode.

To others and I, it makes readibility better.

Examples:


![](https://dl2.pushbulletusercontent.com/DVHEjySSlQHUuBPsbTIsaDxNujbSdlRr/Screenshot_2017-08-20-16-43-37.png)

![](https://dl2.pushbulletusercontent.com/uYyB3ppuPRMCuY8WLse8HKrEnnALmhWa/Screenshot_2017-08-20-16-43-33.png)

![](https://dl2.pushbulletusercontent.com/GOKxGSx1vuQMo38EiLPOL7DdsjMInaHi/Screenshot_2017-08-20-16-43-30.png)
