### PR TITLE
Fix: Notification action for Bike set a walk marker

### DIFF
--- a/app/src/main/java/com/example/earth/fuelfriend/MainActivity.java
+++ b/app/src/main/java/com/example/earth/fuelfriend/MainActivity.java
@@ -638,7 +638,7 @@ public class MainActivity extends AppCompatActivity
             PendingIntent pendingIntentCar = PendingIntent.getBroadcast(context, 0, car_intent, 0);
 
             Intent walk_intent = new Intent();
-            walk_intent.setAction(ACTION_BIKE);
+            walk_intent.setAction(ACTION_WALK);
             PendingIntent pendingIntentWalk = PendingIntent.getBroadcast(context, 0, walk_intent, 0);
 
             NotificationCompat.Builder notificationBuilder =


### PR DESCRIPTION
Wrong string was being passed to the Intent constructor, resulting in the incorrect marker set.

Fixes #41