### PR TITLE
Fix warnings for leaked SQLiteConnections

### DIFF
--- a/app/src/main/java/com/example/earth/fuelfriend/DBHelper.java
+++ b/app/src/main/java/com/example/earth/fuelfriend/DBHelper.java
@@ -121,6 +121,8 @@ class DBHelper extends SQLiteOpenHelper {
             } while (c.moveToNext());
 
         }
+
+        db.close();
         return transport;
     }
 
@@ -144,6 +146,7 @@ class DBHelper extends SQLiteOpenHelper {
             } while (c.moveToNext());
         }
 
+        db.close();
         return markers;
     }
 


### PR DESCRIPTION
Added closing statements to both `getAllTransport()` and `getAllMarkers()`.